### PR TITLE
Display aws account name

### DIFF
--- a/dist/background.js
+++ b/dist/background.js
@@ -1,9 +1,7 @@
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     if (tab.url.match(/https:\/\/.*\.console\.aws\.amazon\.com\/*/)) {
-        console.log("URL matched");
         if (changeInfo.status == "complete") {
             chrome.tabs.sendMessage(tabId, { url: tab.url }, (response) => {
-                console.log("response:" + response);
             });
         }
     }

--- a/dist/background.js
+++ b/dist/background.js
@@ -1,0 +1,10 @@
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+    if (tab.url.match(/https:\/\/.*\.console\.aws\.amazon\.com\/*/)) {
+        console.log("URL matched");
+        if (changeInfo.status == "complete") {
+            chrome.tabs.sendMessage(tabId, { url: tab.url }, (response) => {
+                console.log("response:" + response);
+            });
+        }
+    }
+});

--- a/dist/content.js
+++ b/dist/content.js
@@ -2,7 +2,9 @@ const bgcolor = "lightpink";
 function sleep(timeout) {
     return new Promise(resolve => setTimeout(resolve, timeout));
 }
-sleep(1000).then(draw);
+sleep(1000)
+    .then(draw)
+    .then(storeAccounts);
 function draw() {
     const portalApps = document.getElementsByTagName("portal-application");
     portalApps[0].addEventListener("click", (event) => {
@@ -13,4 +15,32 @@ function draw() {
             }
         });
     });
+}
+function storeAccounts() {
+    const portalApps = document.getElementsByTagName("portal-application");
+    portalApps[0].addEventListener("click", (event) => {
+        const instanceSections = document.getElementsByClassName("instance-section");
+        if (instanceSections.length) {
+            const accounts = AwsAccountDict.parse(instanceSections);
+            console.log(accounts);
+            // LocalStorage に格納する
+        }
+    });
+}
+class AwsAccount {
+    constructor(id, name) {
+        this.id = id;
+        this.name = name;
+    }
+}
+class AwsAccountDict {
+    static parse(elements) {
+        let dict = new AwsAccountDict();
+        Array.prototype.forEach.call(elements, (element) => {
+            const accountName = element.getElementsByClassName("name")[0].textContent;
+            const accountId = element.getElementsByClassName("accountId")[0].textContent.substring(1);
+            dict[accountId] = new AwsAccount(accountId, accountName);
+        });
+        return dict;
+    }
 }

--- a/dist/content.js
+++ b/dist/content.js
@@ -19,12 +19,15 @@ function draw() {
 function storeAccounts() {
     const portalApps = document.getElementsByTagName("portal-application");
     portalApps[0].addEventListener("click", (event) => {
-        const instanceSections = document.getElementsByClassName("instance-section");
-        if (instanceSections.length) {
-            const accounts = AwsAccountDict.parse(instanceSections);
-            console.log(accounts);
-            // LocalStorage に格納する
-        }
+        sleep(200).then((resolve) => {
+            const instanceSections = document.getElementsByClassName("instance-section");
+            if (instanceSections.length) {
+                const accounts = AwsAccountDict.parse(instanceSections);
+                // LocalStorage に格納する
+                chrome.storage.local.set({ awsAccounts: accounts }, () => {
+                });
+            }
+        });
     });
 }
 class AwsAccount {

--- a/dist/globalNav.js
+++ b/dist/globalNav.js
@@ -1,0 +1,33 @@
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    console.log(message.url);
+    if (message.url.match(/https:\/\/.*\.console\.aws\.amazon\.com\/.*/)) {
+        addAccountName();
+        sendResponse({ message: "ok" });
+    }
+});
+function addAccountName() {
+    const nav = document.getElementsByClassName("globalNav-0336")[0];
+    if (nav) {
+        if (nav.getElementsByClassName("aws-account-name").length) {
+            return;
+        }
+        chrome.storage.local.get("awsAccounts").then((resolve) => {
+            const matches = nav.textContent.match(/\d{4}-\d{4}-\d{4}/);
+            const accountId = matches[0].replace(/-/g, "");
+            const account = resolve.awsAccounts[accountId];
+            nav.insertBefore(createAccountNameElement(account.name), nav.firstChild);
+        });
+    }
+}
+// <div class="aws-account-name">
+//   <span>アカウント名: ${AWS_ACCOUNT_NAME}</span>
+// </div>
+function createAccountNameElement(accountName) {
+    const div = document.createElement("div");
+    div.setAttribute("class", "aws-account-name");
+    const span = document.createElement("span");
+    const text = document.createTextNode("アカウント名: " + accountName);
+    span.appendChild(text);
+    div.appendChild(span);
+    return div;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,9 @@
   "description": "Extension of AWS SSO apps page",
   "version": "1.0",
   "manifest_version": 3,
+  "background": {
+    "service_worker": "dist/background.js"
+  },
   "content_scripts": [
     {
       "matches": ["https://*.awsapps.com/*"],
@@ -10,6 +13,7 @@
     }
   ],
   "permissions": [
-    "storage"
+    "storage",
+    "tabs"
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -8,5 +8,8 @@
       "matches": ["https://*.awsapps.com/*"],
       "js": ["dist/content.js"]
     }
+  ],
+  "permissions": [
+    "storage"
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -8,8 +8,14 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://*.awsapps.com/*"],
-      "js": ["dist/content.js"]
+      "matches": [
+        "https://*.awsapps.com/*",
+        "https://*.console.aws.amazon.com/*"
+      ],
+      "js": [
+        "dist/content.js",
+        "dist/globalNav.js"
+      ]
     }
   ],
   "permissions": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,9 +4,71 @@
   "requires": true,
   "packages": {
     "": {
+      "dependencies": {
+        "@extend-chrome/storage": "^1.5.0"
+      },
       "devDependencies": {
+        "@types/chrome": "^0.0.179",
         "typescript": "^4.6.2"
       }
+    },
+    "node_modules/@extend-chrome/storage": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@extend-chrome/storage/-/storage-1.5.0.tgz",
+      "integrity": "sha512-JhoBZ1xIzu0/mauNR/MadUsfNsWP1lTmWR8RlVJvWStUifzNZdAxI2i8NFCkd4RfjyTn4FcDETik3SDlAfGQRA==",
+      "dependencies": {
+        "chrome-promise": "^3.0.5",
+        "rxjs": "^6.5.5 || ^7.1.0"
+      }
+    },
+    "node_modules/@types/chrome": {
+      "version": "0.0.179",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.179.tgz",
+      "integrity": "sha512-60zloNApIf88RwiG3Q7E+4NBG+znchhWmcaEVAAhUZahQbft5LWBzij4sinsfpAwbTtuWdFfUSpZsFhXTEFPVw==",
+      "dev": true,
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
+    "node_modules/@types/filesystem": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.32.tgz",
+      "integrity": "sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/filewriter": "*"
+      }
+    },
+    "node_modules/@types/filewriter": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
+      "integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==",
+      "dev": true
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.8.tgz",
+      "integrity": "sha512-OP6L9VuZNdskgNN3zFQQ54ceYD8OLq5IbqO4VK91ORLfOm7WdT/CiT/pHEBSQEqCInJ2y3O6iCm/zGtPElpgJQ==",
+      "dev": true
+    },
+    "node_modules/chrome-promise": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/chrome-promise/-/chrome-promise-3.0.5.tgz",
+      "integrity": "sha512-ekIevrJOO5S6ezSzl5TdaLhlQkovY5nVaNSgA2XyhuNtlGniUvTbf7rzH95alh1OajArwoP2xVGYUJbpVLmZYA=="
+    },
+    "node_modules/rxjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
+      "integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/typescript": {
       "version": "4.6.2",
@@ -23,6 +85,64 @@
     }
   },
   "dependencies": {
+    "@extend-chrome/storage": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@extend-chrome/storage/-/storage-1.5.0.tgz",
+      "integrity": "sha512-JhoBZ1xIzu0/mauNR/MadUsfNsWP1lTmWR8RlVJvWStUifzNZdAxI2i8NFCkd4RfjyTn4FcDETik3SDlAfGQRA==",
+      "requires": {
+        "chrome-promise": "^3.0.5",
+        "rxjs": "^6.5.5 || ^7.1.0"
+      }
+    },
+    "@types/chrome": {
+      "version": "0.0.179",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.179.tgz",
+      "integrity": "sha512-60zloNApIf88RwiG3Q7E+4NBG+znchhWmcaEVAAhUZahQbft5LWBzij4sinsfpAwbTtuWdFfUSpZsFhXTEFPVw==",
+      "dev": true,
+      "requires": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
+    "@types/filesystem": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.32.tgz",
+      "integrity": "sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==",
+      "dev": true,
+      "requires": {
+        "@types/filewriter": "*"
+      }
+    },
+    "@types/filewriter": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
+      "integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==",
+      "dev": true
+    },
+    "@types/har-format": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.8.tgz",
+      "integrity": "sha512-OP6L9VuZNdskgNN3zFQQ54ceYD8OLq5IbqO4VK91ORLfOm7WdT/CiT/pHEBSQEqCInJ2y3O6iCm/zGtPElpgJQ==",
+      "dev": true
+    },
+    "chrome-promise": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/chrome-promise/-/chrome-promise-3.0.5.tgz",
+      "integrity": "sha512-ekIevrJOO5S6ezSzl5TdaLhlQkovY5nVaNSgA2XyhuNtlGniUvTbf7rzH95alh1OajArwoP2xVGYUJbpVLmZYA=="
+    },
+    "rxjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
+      "integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
     "typescript": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "devDependencies": {
+    "@types/chrome": "^0.0.179",
     "typescript": "^4.6.2"
+  },
+  "dependencies": {
+    "@extend-chrome/storage": "^1.5.0"
   }
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,9 +1,7 @@
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     if (tab.url.match(/https:\/\/.*\.console\.aws\.amazon\.com\/*/)) {
-        console.log("URL matched")
         if (changeInfo.status == "complete") {
             chrome.tabs.sendMessage(tabId, {url: tab.url}, (response) => {
-                console.log("response:" + response);
             });
         }
     }

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,0 +1,10 @@
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+    if (tab.url.match(/https:\/\/.*\.console\.aws\.amazon\.com\/*/)) {
+        console.log("URL matched")
+        if (changeInfo.status == "complete") {
+            chrome.tabs.sendMessage(tabId, {url: tab.url}, (response) => {
+                console.log("response:" + response);
+            });
+        }
+    }
+});

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,7 +1,7 @@
 const bgcolor = "lightpink";
 
 function sleep(timeout: number): Promise<any> {
-  return new Promise(resolve => setTimeout(resolve, timeout))
+    return new Promise(resolve => setTimeout(resolve, timeout))
 }
 
 sleep(1000)
@@ -9,50 +9,53 @@ sleep(1000)
     .then(storeAccounts);
 
 function draw() {
-  const portalApps = document.getElementsByTagName("portal-application");
+    const portalApps = document.getElementsByTagName("portal-application");
 
-  portalApps[0].addEventListener("click", (event) => {
-    const elements = document.getElementsByClassName("name");
-    Array.prototype.forEach.call(elements, (element) => {
-      if (element.textContent.match(/PROD-*/)) {
-        element.parentElement.parentElement.style.backgroundColor = bgcolor;
-      }
+    portalApps[0].addEventListener("click", (event) => {
+        const elements = document.getElementsByClassName("name");
+        Array.prototype.forEach.call(elements, (element) => {
+            if (element.textContent.match(/PROD-*/)) {
+                element.parentElement.parentElement.style.backgroundColor = bgcolor;
+            }
+        });
     });
-  });
 }
 
 function storeAccounts() {
-  const portalApps = document.getElementsByTagName("portal-application");
-  portalApps[0].addEventListener("click", (event) => {
-    const instanceSections = document.getElementsByClassName("instance-section")
-    if (instanceSections.length) {
-      const accounts = AwsAccountDict.parse(instanceSections);
-      console.log(accounts);
-      // LocalStorage に格納する
-    }
-  });
+    const portalApps = document.getElementsByTagName("portal-application");
+    portalApps[0].addEventListener("click", (event) => {
+        sleep(200).then((resolve) => {
+            const instanceSections = document.getElementsByClassName("instance-section")
+            if (instanceSections.length) {
+                const accounts = AwsAccountDict.parse(instanceSections);
+                // LocalStorage に格納する
+                chrome.storage.local.set({awsAccounts: accounts}, () => {
+                });
+            }
+        });
+    });
 }
 
 class AwsAccount {
-  id: string
-  name: string
+    id: string
+    name: string
 
-  constructor(id: string, name: string) {
-    this.id = id;
-    this.name = name;
-  }
+    constructor(id: string, name: string) {
+        this.id = id;
+        this.name = name;
+    }
 }
 
 class AwsAccountDict {
-  [id: string]: AwsAccount
+    [id: string]: AwsAccount
 
-  static parse(elements: HTMLCollectionOf<Element>): AwsAccountDict {
-    let dict = new AwsAccountDict();
-    Array.prototype.forEach.call(elements,(element) => {
-      const accountName = element.getElementsByClassName("name")[0].textContent;
-      const accountId = element.getElementsByClassName("accountId")[0].textContent.substring(1);
-      dict[accountId] = new AwsAccount(accountId, accountName);
-    })
-    return dict
-  }
+    static parse(elements: HTMLCollectionOf<Element>): AwsAccountDict {
+        let dict = new AwsAccountDict();
+        Array.prototype.forEach.call(elements, (element) => {
+            const accountName = element.getElementsByClassName("name")[0].textContent;
+            const accountId = element.getElementsByClassName("accountId")[0].textContent.substring(1);
+            dict[accountId] = new AwsAccount(accountId, accountName);
+        })
+        return dict
+    }
 }

--- a/src/content.ts
+++ b/src/content.ts
@@ -4,7 +4,9 @@ function sleep(timeout: number): Promise<any> {
   return new Promise(resolve => setTimeout(resolve, timeout))
 }
 
-sleep(1000).then(draw);
+sleep(1000)
+    .then(draw)
+    .then(storeAccounts);
 
 function draw() {
   const portalApps = document.getElementsByTagName("portal-application");
@@ -17,4 +19,40 @@ function draw() {
       }
     });
   });
+}
+
+function storeAccounts() {
+  const portalApps = document.getElementsByTagName("portal-application");
+  portalApps[0].addEventListener("click", (event) => {
+    const instanceSections = document.getElementsByClassName("instance-section")
+    if (instanceSections.length) {
+      const accounts = AwsAccountDict.parse(instanceSections);
+      console.log(accounts);
+      // LocalStorage に格納する
+    }
+  });
+}
+
+class AwsAccount {
+  id: string
+  name: string
+
+  constructor(id: string, name: string) {
+    this.id = id;
+    this.name = name;
+  }
+}
+
+class AwsAccountDict {
+  [id: string]: AwsAccount
+
+  static parse(elements: HTMLCollectionOf<Element>): AwsAccountDict {
+    let dict = new AwsAccountDict();
+    Array.prototype.forEach.call(elements,(element) => {
+      const accountName = element.getElementsByClassName("name")[0].textContent;
+      const accountId = element.getElementsByClassName("accountId")[0].textContent.substring(1);
+      dict[accountId] = new AwsAccount(accountId, accountName);
+    })
+    return dict
+  }
 }

--- a/src/globalNav.ts
+++ b/src/globalNav.ts
@@ -1,0 +1,36 @@
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    console.log(message.url);
+    if (message.url.match(/https:\/\/.*\.console\.aws\.amazon\.com\/.*/)) {
+        addAccountName();
+        sendResponse({ message: "ok" })
+    }
+});
+
+function addAccountName(): void {
+    const nav = document.getElementsByClassName("globalNav-0336")[0];
+    if (nav) {
+        if (nav.getElementsByClassName("aws-account-name").length) {
+            return
+        }
+
+        chrome.storage.local.get("awsAccounts").then((resolve) => {
+            const matches = nav.textContent.match(/\d{4}-\d{4}-\d{4}/);
+            const accountId = matches[0].replace(/-/g, "");
+            const account = resolve.awsAccounts[accountId];
+            nav.insertBefore(createAccountNameElement(account.name), nav.firstChild)
+        })
+    }
+}
+
+// <div class="aws-account-name">
+//   <span>アカウント名: ${AWS_ACCOUNT_NAME}</span>
+// </div>
+function createAccountNameElement(accountName: string): Element {
+    const div = document.createElement("div")
+    div.setAttribute("class", "aws-account-name")
+    const span = document.createElement("span")
+    const text = document.createTextNode("アカウント名: " + accountName)
+    span.appendChild(text)
+    div.appendChild(span)
+    return div
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
   "compilerOptions": {
     "target": "es2016",
     "rootDir": "src",
+    "typeRoots": ["./node_modules/@types"],
+    "types": ["chrome"],
     "outDir": "dist"
   },
 }


### PR DESCRIPTION
アカウント名と ID の辞書は、 start page のリストからスクレイピングして取得する

取得した辞書を Chrome Storage API にて永続化する ※まずは local に保存

ページの遷移を補足するために tab.onUpdated をハンドリングして content-script にメッセージする

globalNav.js にて background から送られたメッセージを補足し、URL が AWS マネジメントコンソールであれば AWS アカウント ID を画面から拾ってきて Chrome Storage に格納した辞書に引き当てる

引き当てて AWS アカウント論理名を右上の global-nav に AWS アカウント論理名を差し込む

# Isses

AWS マネジメントコンソールにアカウント名（論理名）を表示したい #3