### PR TITLE
Change timing that 'portal-application' tag existence check

### DIFF
--- a/dist/content.js
+++ b/dist/content.js
@@ -2,10 +2,19 @@ const bgcolor = "lightpink";
 function sleep(timeout) {
     return new Promise(resolve => setTimeout(resolve, timeout));
 }
-if (document.getElementsByTagName("portal-application").length) {
-    sleep(1000)
-        .then(draw)
-        .then(storeAccounts);
+sleep(1000)
+    .then(findElement)
+    .then(draw)
+    .then(storeAccounts);
+function findElement() {
+    return new Promise((resolve, reject) => {
+        if (document.getElementsByTagName("portal-application").length) {
+            resolve("Element is exists.");
+        }
+        else {
+            reject("Element is not exists.");
+        }
+    });
 }
 function draw() {
     const portalApps = document.getElementsByTagName("portal-application");

--- a/src/content.ts
+++ b/src/content.ts
@@ -4,10 +4,19 @@ function sleep(timeout: number): Promise<any> {
     return new Promise(resolve => setTimeout(resolve, timeout))
 }
 
-if (document.getElementsByTagName("portal-application").length) {
-    sleep(1000)
-        .then(draw)
-        .then(storeAccounts);
+sleep(1000)
+    .then(findElement)
+    .then(draw)
+    .then(storeAccounts);
+
+function findElement() {
+    return new Promise<string>((resolve, reject) => {
+        if (document.getElementsByTagName("portal-application").length) {
+            resolve("Element is exists.");
+        } else {
+            reject("Element is not exists.");
+        }
+    })
 }
 
 function draw() {


### PR DESCRIPTION
`<portal-application>` タグの有無で DOM 操作を行うかを判定していたが、 sleep 前に行うとタグが document 内に生成されておらず DOM 操作がスルーされてしまっていた

sleep したあとにまずは filter する関数を実行し、その Promise の結果で後続の処理を行うように修正した

# Issue
PROD- アカウントに背景色がつかない #13